### PR TITLE
Configure additional package via CI

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   push:
     # Triggers on every tag starting with v
@@ -11,6 +11,11 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      openwrtAddPackages:
+        description: "Additonal packages"
+        required: false
+        default: ""
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -28,7 +33,7 @@ jobs:
         run: sudo apt install libfdt-dev cmake
 
       - name: Run builder script
-        run: mkdir -m 0700 $HOME/.gnupg ; bash build_installer.sh
+        run: mkdir -m 0700 $HOME/.gnupg ; bash build_installer.sh "${{ github.event.inputs.openwrtAddPackages }}"
 
 #      - name: Store created images
 #        uses: actions/upload-artifact@v2
@@ -83,4 +88,3 @@ jobs:
           asset_path: ./${{ env.INSTALLER_ITB }}
           asset_name: ${{ env.INSTALLER_ITB }}
           asset_content_type: application/octet-stream
-

--- a/build_installer.sh
+++ b/build_installer.sh
@@ -23,6 +23,7 @@ DTC=
 FILEBASE=
 WORKDIR=
 ITSFILE=
+OPENWRT_ADD_PACKAGES=$*
 
 run_openwrt_ib() {
 	mkdir -p "${INSTALLERDIR}/dl"
@@ -237,7 +238,6 @@ linksys_e8450_installer() {
 	owrt_version="$(wget -q -O - https://downloads.openwrt.org/releases/22.03-SNAPSHOT/targets/mediatek/mt7622/version.buildinfo)"
 	OPENWRT_INITRD="openwrt-22.03-snapshot-${owrt_version}-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery.itb"
 	OPENWRT_REMOVE_PACKAGES="luci-ssl wpad-basic-wolfssl libustream-wolfssl* px5g-wolfssl libwolfssl*"
-	OPENWRT_ADD_PACKAGES=""
 	OPENWRT_ADD_REC_PACKAGES="wpad-openssl libustream-openssl luci luci-ssl-openssl luci-theme-openwrt-2020 kmod-mtd-rw"
 	OPENWRT_ENABLE_SERVICE="uhttpd wpad"
 


### PR DESCRIPTION
Hello!
first of all, thanks for the work on this project! 

I recently forked the repo and try to compile the firmware with some additional packages. After some [yak shaving](http://www.catb.org/~esr/jargon/html/Y/yak-shaving.html) configuring the environment (I am on MacOs) I decided to leverage the pipeline on GH actions to create the custom firmware :) 

To make it work I simply changed the `build_installer.sh` with the additional packages and triggered the build. 

Thinking about how I could make it slightly better for my needs, I then added a parameter to the GH action so that the packages can be configured when running the pipeline (this PR).
Do you think this could be something useful for other people too? looking at the forks, it seems that people fork 'just' to add additional packages.

If you think this makes sense to have on master, I could add some bits of docs.

Thanks again!
