### PR TITLE
Update Containerfile

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -17,7 +17,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM ubuntu:22.04
 RUN apt-get update && apt-get dist-upgrade -y && apt-get -y install \
     build-essential \
     diffutils \

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get dist-upgrade -y && apt-get -y install \
     build-essential \
     diffutils \


### PR DESCRIPTION
Using bullseye-slim instead of bullseye saves about 100MB in the resulting image. Not huge but every little bit helps.

```
REPOSITORY                        TAG             IMAGE ID       CREATED          SIZE
owrt                              latest          e63400b3f114   14 seconds ago   1.11GB
owrt-slim                         latest          6fae00390136   9 minutes ago    1.01GB
```