### PR TITLE
install.sh: when files missing call exit

### DIFF
--- a/files/installer/install.sh
+++ b/files/installer/install.sh
@@ -17,6 +17,7 @@ HAS_ENV=1
 if [ ! -s "$PRELOADER" ] || [ ! -s "$FIP" ] || [ ! -s "$RECOVERY" ]; then
 	echo "Missing files. Aborting."
 	reboot
+	exit 1
 fi
 
 install_fix_factory() {


### PR DESCRIPTION
When call reboot the script still gets executed.
Add exit 1 to be sure nothing will be touched.