### PR TITLE
Switch to all-UBI flash layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ https://user-images.githubusercontent.com/82453643/147394017-e7af122c-8234-4f11-
 
 *Showing the installation process. The window on the right displays the serial RX interface for documentation purpose only. The interaction required is shown on the left, which is done entirely within the web browser.*
 
-**WARNING #1** This will replace the bootloader (TF-A 2.9, U-Boot 2023.07.02) and convert the flash layout of the device to [UBI](https://github.com/dangowrt/linksys-e8450-openwrt-installer/issues/9). The installer stores a copy of the previous bootchain in a dedicated UBI volume `boot_backup`.
+**WARNING #1** This will replace the bootloader (TF-A 2.9, U-Boot 2024.01) and convert the flash layout of the device to [UBI](https://github.com/dangowrt/linksys-e8450-openwrt-installer/issues/9). The installer stores a copy of the previous bootchain in a dedicated UBI volume `boot_backup`.
 
 **WARNING #2** Re-flashing the installer when the device is already using UBI flash layout will erase the previously backed up bootchain, which in most cases would be the vendor/official one.
 
 If you plan to ever go back to the stock firmware, you will need a backup of the vendor bootchain and firmware. When going back to the stock firmware, be prepared to connect to the internal serial port in case there are any bad blocks.
 
-**WARNING #3** The installer is meant to be executed only once per device. Executing the installer more than once should be avoided! Use normal *-linksys_e8450-ubi-squashfs-sysupgrade.itb images provided by openwrt.org instead.
+**WARNING #3** The installer is meant to be executed only once per device unless an update explicitely requires a bootloader update. In that case, make sure to copy the content of the `boot_backup` UBI volume off the device before re-running the installer, so you will still have a copy of the stock bootchain! Executing the installer more than once should be avoided in all other cases! Use normal *-linksys_e8450-ubi-squashfs-sysupgrade.itb images provided by openwrt.org instead.
 
 ## Table of Contents
 * [Script information](#script-information)


### PR DESCRIPTION
ARM TrustedFirmware-A now supports loading fip from UBI. Let's use that, so that fip enjoys some scrubbing which seems to be needed...
Also move factory EEPROMs and MAC addresses to static UBI volume instead of keeping it in the raw flash for the same reason.

Depends on https://github.com/openwrt/openwrt/pull/14140 to be merged and buildbot phase1 **and phase2** run completed as the big change is here: https://github.com/openwrt/openwrt/pull/14140/commits/35bace7921787db8cc8c838547332d66be19d9a5