### PR TITLE
Add zstd to dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You'll need the below to use the script to generate the installer image:
 * All [prerequisites of the OpenWrt ImageBuilder](https://openwrt.org/docs/guide-user/additional-software/imagebuilder#prerequisites) 
 * `libfdt-dev`
 * `cmake`
+* `zstd`
 
 **If you are not interested in building yourself**, the pre-built files are available [here](https://github.com/dangowrt/linksys-e8450-openwrt-installer/releases).
 


### PR DESCRIPTION
In https://github.com/dangowrt/owrt-ubi-installer/issues/184 build_installer.sh switched from downloading a `xz` file to a `zst` file so now `zstd` is necessary. Since this is not a default package (it is not included in the `ubuntu:latest` docker image) it should be listed in the required dependecies.