### PR TITLE
Update README.md - minor readability changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ You'll need the below to use the script to generate the installer image:
 6. You should then be greeted by the login screen, the stock password is "admin".
 7. Navigate to __Administration__ -> __Firmware Upgrade__.
 8. Upload the firmware "installer" image
-  * If running stock firmware < 1.2.00.273012, upload the **unsigned** image: `openwrt-...-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery-installer.itb`
-  * Otherwise, when stock firmware is >= 1.2.00.273012, upload the **signed** image: `openwrt-...-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery-installer_signed.itb`
+   * If running stock firmware < 1.2.00.273012, upload the **unsigned** image: `openwrt-...-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery-installer.itb`
+   * Otherwise, when stock firmware is >= 1.2.00.273012, upload the **signed** image: `openwrt-...-mediatek-mt7622-linksys_e8450-ubi-initramfs-recovery-installer_signed.itb`
 9. Wait for a minute, the OpenWrt recovery image should come up.
-9. Navigate to __System__ -> __Backup / Flash Firmware__.
-10. Upload `openwrt-...-mediatek-mt7622-linksys_e8450-ubi-squashfs-sysupgrade.itb`.
+10. Navigate to __System__ -> __Backup / Flash Firmware__.
+11. Upload `openwrt-...-mediatek-mt7622-linksys_e8450-ubi-squashfs-sysupgrade.itb`.
 12. The device will reboot, you may proceed to setup OpenWrt.
 13. Follow the [post install tips in the OpenWrt Wiki](https://openwrt.org/toh/linksys/e8450#post_install_tips). You may proceed to setup OpenWrt.
 
-## Downgrading Firmware - (If installer image upload was rejected)
+## Downgrading Stock Firmware - (If installer image upload was rejected)
 * **IMPORTANT: Before downgrading, verify that the rejected upload was the correct, signed or unsigned, installer image to use for the currently running firmware version. (i.e. Maybe try uploading the 'other' installer image file first.)  Most rejected uploads are probably related to signed vs. unsigned image compatibility.**
 * **Note: It may not be possible to downgrade devices with "signed" stock firmware, i.e. versions >= 1.2.00.273012.**
 1. Download Stock Vendor Firmware
- * For Linksys E8450 [FW_E8450_1.0.01.101415_prod.img] (https://downloads.linksys.com/support/assets/firmware/FW_E8450_1.0.01.101415_prod.img)
- * For Belkin RT3200 [FW_RT3200_1.0.01.101415_prod.img] (https://s3.belkin.com/support/assets/belkin/firmware/FW_RT3200_1.0.01.101415_prod.img)
+   * For Linksys E8450 [FW_E8450_1.0.01.101415_prod.img] (https://downloads.linksys.com/support/assets/firmware/FW_E8450_1.0.01.101415_prod.img)
+   * For Belkin RT3200 [FW_RT3200_1.0.01.101415_prod.img] (https://s3.belkin.com/support/assets/belkin/firmware/FW_RT3200_1.0.01.101415_prod.img)
 2. Upload / install the Vendor 1.0.x Firmware (using the normal procedure)
 
 ## Backup stock/vendor bootchain


### PR DESCRIPTION
Just some minor changes to make the rendered and unrendered readme file more readable.
- Bullet point indent to render proper hierarchy.
- Add stock to be clear about when these downgrade instructions apply.
- Fix numbered list code 9,9,10,12 to 9,10,11,12

Maybe I am just an idiot, but the addition of "stock" really helps me remember at a glance that that section is purely for vendor firmware → vendor firmware downgrades; which I personally am sometimes confused when I have the forum thread, wiki, and GitHub page up in separate tabs and keep switching back and forth to make sure I am understanding what I think I am understanding.